### PR TITLE
support pre 5.3.0, T_PAAMAYIM_NEKUDOTAYIM fix

### DIFF
--- a/CFile.php
+++ b/CFile.php
@@ -198,9 +198,8 @@ class CFile extends CApplicationComponent {
             }
 
             clearstatcache();
-            $cl = get_class($this);
-            $realPath = $cl::realPath($filepath);
-            $inst = $cl::getInstance($realPath);
+            $realPath = $this->realPath($filepath);
+            $inst = self::getInstance($realPath);
             $inst->_filepath = $filepath;
             $inst->_realpath = $realPath;
 


### PR DESCRIPTION
As you say that the requirements are PHP 5.1+ I made this little change. Late static binding is available only from PHP 5.3.
