### PR TITLE
Added a method resolving relative filesystem object path.

### DIFF
--- a/CFile.php
+++ b/CFile.php
@@ -285,6 +285,26 @@ class CFile extends CApplicationComponent {
 
         return $this->_realpath;
     }
+    
+    /**
+     * Returns relative filesystem object path figured by script on the basis of $_realpath
+     *
+     * @return string Relative file path
+     */
+    public function getRelativePath() {
+        $current_path = getcwd();
+        if ($current_path === "/")
+        {
+            return $this->_realpath;
+        }
+        else if (substr($this->_realpath,0,strlen($current_path)) === $current_path ) {
+            return substr($this->_realpath,strlen($current_path));
+        }
+        else
+        {
+            throw new CFileException('Unable to resolve relative path for filesystem object.');
+        }
+    }
 
     /**
      * Base real filesystem object path resolving method.

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -64,6 +64,31 @@ class CFileHelperTests extends PHPUnit_Framework_TestCase {
         $this->assertEquals((string)$this->cf, $this->filepath);
     }
 
+    public function testGetRelativePath() {
+        $cf = $this->cf;
+        $cf->create();
+
+        // Save the current working directory for the last test-case
+        $current_working_directory = getcwd();
+
+        // Current working directory is the root directory
+        chdir('/');
+        $relative_path_expected = sys_get_temp_dir() . '/' . $cf->getFilename();
+        $relative_path_actual = $cf->getRelativePath();
+        $this->assertEquals($relative_path_expected,$relative_path_actual);
+
+        // Current working directory is within the file path
+        chdir(sys_get_temp_dir() . '/');
+        $relative_path_expected = '/' . $cf->getFilename();
+        $relative_path_actual = $cf->getRelativePath();
+        $this->assertEquals($relative_path_expected,$relative_path_actual);
+
+        // Current working directory is outside of the file path
+        chdir($current_working_directory);
+        $this->setExpectedException('CFileException','Unable to resolve relative path for filesystem object.');
+        $cf->getRelativePath();
+    }
+
     public function testSetOwner() {
         $cf = $this->cf;
         $cf->create();


### PR DESCRIPTION
A use-case of the method: a web-accessible directory "httpdocs/photos" contains a number of photos which should be shown on the web-page. A script scans the directory and retrieves relative paths of photos. Then photos may be referenced by their relative paths.

Example:

``` php
public function getPhotos()
{
    $photos = array();
    $photosDirectory = Yii::app()->file->set("photos");
    $photosPaths = $photosDirectory->getContents(false,'jpg');
    foreach ( $photosPaths as $photoPath )
    {
        $photoFile = Yii::app()->file->set($photoPath);
        $photoFileRelativePath = $photoFile->getRelativePath();
        $photos[] = $photoFileRelativePath;
    }
    return $photos;
}

public function printPhotos()
{
    $photos = getPhotos();
    echo '<ul>'
    foreach ( $photos as $photo )
    {
        echo '<li><img src="' . $photo . '"></li>';
    }
    echo '</ul>';
}
```

The method does not yet support the case when the current working directory is higher than the file in the file system hierarchy and when the current working directory is outside of the file path but still may me useful in other cases.
